### PR TITLE
Add macro navigation actions + payload schema (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.0] - 2026-01-08
+
+### Added
+- Macro button action: Go to a specific screen (dropdown-driven).
+- Macro button action: Back (previous screen) with safe fallback to `macro1`.
+
+### Changed
+- BREAKING: `/api/macros` schema replaces `script` with `payload` and adds actions `nav_to` + `go_back`.
+
 ## [1.2.0] - 2026-01-08
 
 ### Added

--- a/src/app/display_manager.cpp
+++ b/src/app/display_manager.cpp
@@ -537,6 +537,31 @@ bool DisplayManager::showScreen(const char* screen_id) {
     return false;
 }
 
+bool DisplayManager::goBackOrDefault() {
+    // Do not treat splash or unregistered screens as valid targets.
+    Screen* target = previousScreen;
+    if (!target || target == currentScreen) {
+        return showScreen("macro1");
+    }
+
+    // Only allow navigating back to registered runtime screens.
+    bool registered = false;
+    for (size_t i = 0; i < screenCount; i++) {
+        if (availableScreens[i].instance == target) {
+            registered = true;
+            break;
+        }
+    }
+
+    if (!registered) {
+        return showScreen("macro1");
+    }
+
+    pendingScreen = target;
+    Logger.logMessage("Display", "Queued go-back to previous screen");
+    return true;
+}
+
 const char* DisplayManager::getCurrentScreenId() {
     // Return ID of current screen (nullptr if splash or unknown)
     for (size_t i = 0; i < screenCount; i++) {

--- a/src/app/display_manager.h
+++ b/src/app/display_manager.h
@@ -163,6 +163,10 @@ public:
     
     // Screen selection by ID (thread-safe, returns true if found)
     bool showScreen(const char* screen_id);
+
+    // Return to previous runtime screen when available; otherwise go to default ("macro1").
+    // Returns true when a navigation was queued.
+    bool goBackOrDefault();
     
     // Get current screen ID (returns nullptr if splash or no screen)
     const char* getCurrentScreenId();

--- a/src/app/ducky_script.cpp
+++ b/src/app/ducky_script.cpp
@@ -180,7 +180,7 @@ bool ducky_execute(const char* script, BleKeyboardManager* keyboard) {
     }
 
     // Copy into a scratch buffer so we can split lines in-place.
-    // Macro strings are bounded by MACROS_SCRIPT_MAX_LEN (256), but keep a little headroom.
+    // Macro payload strings are bounded by MACROS_PAYLOAD_MAX_LEN (256), but keep a little headroom.
     char buf[384];
     strlcpy(buf, script, sizeof(buf));
 

--- a/src/app/macros_config.cpp
+++ b/src/app/macros_config.cpp
@@ -20,7 +20,7 @@
 #define KEY_BLOB  "b"
 
 #define MACROS_MAGIC 0x4D414352u // 'MACR'
-#define MACROS_VERSION 7
+#define MACROS_VERSION 8
 
 static Preferences prefs;
 
@@ -185,7 +185,7 @@ void macros_config_set_defaults(MacroConfig* cfg) {
         for (int b = 0; b < MACROS_BUTTONS_PER_SCREEN; b++) {
             cfg->buttons[s][b].action = MacroButtonAction::None;
             cfg->buttons[s][b].label[0] = '\0';
-            cfg->buttons[s][b].script[0] = '\0';
+            cfg->buttons[s][b].payload[0] = '\0';
 
             cfg->buttons[s][b].icon.type = MacroIconType::None;
             cfg->buttons[s][b].icon.id[0] = '\0';

--- a/src/app/macros_config.h
+++ b/src/app/macros_config.h
@@ -24,7 +24,7 @@
 // Keep sizes conservative to avoid RAM pressure.
 // Note: macros are stored in NVS as a single blob; size changes invalidate stored config.
 #define MACROS_LABEL_MAX_LEN 16
-#define MACROS_SCRIPT_MAX_LEN 256
+#define MACROS_PAYLOAD_MAX_LEN 256
 #define MACROS_ICON_ID_MAX_LEN 32
 // UTF-8 bytes (not Unicode code points). Keep generous to support ZWJ emoji sequences.
 #define MACROS_ICON_DISPLAY_MAX_LEN 64
@@ -42,6 +42,8 @@ enum class MacroButtonAction : uint8_t {
     SendKeys = 1,
     NavPrevScreen = 2,
     NavNextScreen = 3,
+    NavToScreen = 4,
+    GoBack = 5,
 };
 
 enum class MacroIconType : uint8_t {
@@ -62,7 +64,11 @@ struct MacroButtonIcon {
 struct MacroButtonConfig {
     char label[MACROS_LABEL_MAX_LEN];
     MacroButtonAction action;
-    char script[MACROS_SCRIPT_MAX_LEN];
+    // Generic action payload.
+    // - SendKeys: DuckyScript-like payload
+    // - NavToScreen: target screen id (e.g. "macro1", "info")
+    // - Others: unused for now
+    char payload[MACROS_PAYLOAD_MAX_LEN];
     MacroButtonIcon icon;
 
     // Optional per-button appearance overrides (0xRRGGBB or MACROS_COLOR_UNSET).

--- a/src/app/screens/macropad_screen.cpp
+++ b/src/app/screens/macropad_screen.cpp
@@ -48,6 +48,8 @@ static const char* actionToShortLabel(MacroButtonAction a) {
         case MacroButtonAction::SendKeys: return "Send";
         case MacroButtonAction::NavPrevScreen: return "Prev";
         case MacroButtonAction::NavNextScreen: return "Next";
+        case MacroButtonAction::NavToScreen: return "Go";
+        case MacroButtonAction::GoBack: return "Back";
         default: return "—";
     }
 }
@@ -751,14 +753,34 @@ void MacroPadScreen::handleButtonClick(uint8_t b) {
         return;
     }
 
+    if (btnCfg->action == MacroButtonAction::GoBack) {
+        // Best-effort: if no previous screen is tracked, fall back to Macro 1.
+        if (!displayMgr->goBackOrDefault()) {
+            displayMgr->showScreen("macro1");
+        }
+        return;
+    }
+
+    if (btnCfg->action == MacroButtonAction::NavToScreen) {
+        const char* target = btnCfg->payload;
+        if (!target || target[0] == '\0') {
+            displayMgr->showScreen("macro1");
+            return;
+        }
+        if (!displayMgr->showScreen(target)) {
+            displayMgr->showScreen("macro1");
+        }
+        return;
+    }
+
     if (btnCfg->action == MacroButtonAction::SendKeys) {
-        if (btnCfg->script[0] == '\0') {
-            Logger.logMessage("Macro", "Empty script; skipping");
+        if (btnCfg->payload[0] == '\0') {
+            Logger.logMessage("Macro", "Empty payload; skipping");
             return;
         }
 
         BleKeyboardManager* kb = getBleKeyboard();
-        ducky_execute(btnCfg->script, kb);
+        ducky_execute(btnCfg->payload, kb);
         return;
     }
 }

--- a/src/app/web/home.html
+++ b/src/app/web/home.html
@@ -80,23 +80,31 @@
                         <div class="form-group">
                             <label for="macro_action">Button action</label>
                             <select id="macro_action" name="macro_action">
-                                <option value="none">None (hidden)</option>
-                                <option value="send_keys">Keys Script</option>
-                                <option value="nav_prev">Previous Screen</option>
-                                <option value="nav_next">Next Screen</option>
+                                <option value="none">No Action (button hidden)</option>
+                                <option value="send_keys">Send Keys (Script)</option>
+                                <option value="nav_prev">Previous Macro Page</option>
+                                <option value="nav_next">Next Macro Page</option>
+                                <option value="nav_to">Go to Screen</option>
+                                <option value="go_back">Back (Previous Screen)</option>
                             </select>
                             <small>Navigation wraps (Screen 1 ↔ Screen 8).</small>
                         </div>
 
-                        <div class="form-group" id="macro_script_group">
+                        <div class="form-group" id="macro_nav_to_group" style="display:none;">
+                            <label for="macro_nav_target">Target screen</label>
+                            <select id="macro_nav_target" name="macro_nav_target"></select>
+                            <small>Used when Action is <strong>Go to Screen</strong>.</small>
+                        </div>
+
+                        <div class="form-group" id="macro_payload_group">
                             <div class="label-row">
-                                <label for="macro_script">Keys Script</label>
+                                <label for="macro_payload">Send Keys (Script)</label>
                                 <button type="button" class="link-button" id="ducky_help_open" aria-haspopup="dialog" aria-controls="ducky_help_overlay">Syntax help</button>
                             </div>
-                            <textarea id="macro_script" name="macro_script" rows="5" maxlength="255" placeholder="Example:&#10;STRING Hello world&#10;ENTER&#10;"></textarea>
-                            <small id="macro_script_help">
-                                Used when Action is <strong>Keys Script</strong> (DuckyScript-like subset).
-                                <span style="margin-left: 8px;">Chars: <span id="macro_script_chars">0</span>/255</span>
+                            <textarea id="macro_payload" name="macro_payload" rows="5" maxlength="255" placeholder="Example:&#10;STRING Hello world&#10;ENTER&#10;"></textarea>
+                            <small id="macro_payload_help">
+                                Used when Action is <strong>Send Keys (Script)</strong> (DuckyScript-like subset).
+                                <span style="margin-left: 8px;">Chars: <span id="macro_payload_chars">0</span>/255</span>
                             </small>
                         </div>
 
@@ -105,7 +113,7 @@
                             <div class="reboot-modal ducky-help-modal">
                                 <div class="ducky-help-header">
                                     <button type="button" class="link-button" id="ducky_help_close" aria-label="Close">Close</button>
-                                    <h2 id="ducky_help_title" style="margin: 0;">Keys Script (DuckyScript subset)</h2>
+                                    <h2 id="ducky_help_title" style="margin: 0;">Send Keys (DuckyScript subset)</h2>
                                 </div>
 
                                 <p style="margin: 0 0 10px 0;">Commands and tokens are case-insensitive. Unknown tokens are ignored and logged.</p>

--- a/src/app/web/portal.css
+++ b/src/app/web/portal.css
@@ -637,8 +637,8 @@ textarea {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
-/* Macros editor: keep the Keys Script box compact by default */
-#macro_script {
+/* Macros editor: keep the Send Keys box compact by default */
+#macro_payload {
     min-height: 80px;
 }
 

--- a/src/version.h
+++ b/src/version.h
@@ -5,7 +5,7 @@
 
 // Firmware version information
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 2
+#define VERSION_MINOR 3
 #define VERSION_PATCH 0
 
 // Build date (automatically set by compiler)


### PR DESCRIPTION
## Summary
- Adds two macro button actions:
  - **Go to Screen** (`nav_to`) using a dropdown populated from `/api/info` `available_screens`.
  - **Back (previous screen)** (`go_back`) with safe fallback to `macro1`.
- Migrates macro button parameter field from `script` to a generic `payload` for future action extensibility.

## Breaking change
- `/api/macros` schema: `script` → `payload`, and new actions `nav_to` + `go_back`.
- Macro config storage version bumped (auto-reset on mismatch).

## UI
- Portal Macros editor updated to show the right editor per action:
  - Textarea for **Send Keys (Script)**
  - Dropdown for **Go to Screen**

## Version
- Bumps firmware version to **1.3.0** and updates `CHANGELOG.md`.

## Testing
- `./build.sh` (local)