### PR TITLE
Fix USB CDC boot/logging + jc3636w518 stability (v1.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.4.3] - 2026-01-13
+
+### Fixed
+- Avoid boot dependency on a connected USB CDC host by skipping `Serial.begin()` when `ARDUINO_USB_CDC_ON_BOOT` is enabled.
+- Restore early boot logs on USB CDC boards by falling back to ROM console output until the CDC port is opened.
+- Mitigate LVGL-related panics on `jc3636w518` by preferring internal (DMA-capable) ESP_Panel swap buffer allocation.
+- Prevent icon cache eviction from invalidating LVGL image descriptors while rendering.
+
 ## [1.4.2] - 2026-01-11
 
 ### Changed

--- a/src/boards/jc3636w518/board_overrides.h
+++ b/src/boards/jc3636w518/board_overrides.h
@@ -71,7 +71,11 @@
 // Prefer PSRAM first for LVGL draw buffer (fallback handled in DisplayManager).
 #define LVGL_BUFFER_PREFER_INTERNAL false
 // Prefer PSRAM first for the ESP_Panel ST77916 swap buffer (fallbacks exist).
-#define ESP_PANEL_SWAPBUF_PREFER_INTERNAL false
+// NOTE: The swap buffer is used as the source for QSPI flush DMA operations.
+// PSRAM-backed buffers are not reliably DMA-accessible across cores/IDF versions
+// and can lead to hard-to-debug memory corruption/panics under LVGL rendering.
+// Keep this in internal (DMA-capable) RAM for stability.
+#define ESP_PANEL_SWAPBUF_PREFER_INTERNAL true
 // LVGL draw buffer size in pixels.
 #define LVGL_BUFFER_SIZE (DISPLAY_WIDTH * 16)  // 16 rows (matches sample default)
 

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 4
-#define VERSION_PATCH 2
+#define VERSION_PATCH 3
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
Fixes a set of boot + stability issues seen on USB-CDC-on-boot ESP32 targets (notably ESP32-S3) and mitigates a LVGL-related panic on `jc3636w518`.

## What changed
- **USB CDC boot reliability**: `LogManager::begin()` skips `Serial.begin()` when `ARDUINO_USB_CDC_ON_BOOT` is enabled, avoiding boot behavior that depends on having a host/monitor attached.
- **Early log visibility**: when USB CDC isn’t opened yet, logger falls back to ROM console output (`esp_rom_printf`) instead of dropping logs.
- **`jc3636w518` display stability**: prefer internal (DMA-capable) memory for the ESP_Panel swap buffer via `ESP_PANEL_SWAPBUF_PREFER_INTERNAL`, reducing risk of DMA/PSRAM-related corruption under LVGL rendering.
- **Icon cache safety**: make the file-backed icon cache non-evicting so we don’t invalidate `lv_img_dsc_t` pointers while LVGL is still rendering.
- **Release hygiene**: bump firmware version to **1.4.3** and add changelog entry.

## Files
- `src/app/log_manager.cpp`
- `src/boards/jc3636w518/board_overrides.h`
- `src/app/icon_store.cpp`
- `src/version.h`
- `CHANGELOG.md`

## Testing
- Built/ran locally via `./bum.sh` (build + upload + monitor).  
- Manual validation on USB-CDC board:
  - boots with no serial monitor connected
  - boots with serial monitor attached
  - early logs visible (ROM console until CDC opens)

## Notes
This PR intentionally avoids any behavior that would block boot on CDC readiness; logging remains best-effort during early boot.