### PR TITLE
Health overlay + telemetry robustness (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.0] - 2026-01-14
+
+### Added
+- Add a runtime diagnostics “health overlay” with sparklines (CPU usage, internal heap free, PSRAM free when present, WiFi RSSI).
+- Add firmware-side window sampling (200ms, FreeRTOS timer) to capture heap/PSRAM min/max and related extrema between `/api/health` polls.
+- Add cached filesystem health fields to `/api/health` (no mounting/probing inside the request handler).
+- Add MQTT connection/publish health fields to `/api/health`.
+- Add display performance stats to `/api/health` when `HAS_DISPLAY` is enabled.
+
+### Changed
+- Make `/api/health` and the portal UI treat CPU usage as unknown when runtime stats are unavailable (return `null`, render `—`, don’t record a bogus 0% sample).
+- Avoid per-request `String` heap churn for IP formatting in `/api/health` by using a fixed-size buffer.
+- Remove CPU usage min/max fields everywhere (API/UI/MQTT/Home Assistant discovery).
+- Update the compile-time flags report documentation.
+
 ## [1.4.3] - 2026-01-13
 
 ### Fixed

--- a/docs/compile-time-flags.md
+++ b/docs/compile-time-flags.md
@@ -12,7 +12,7 @@ This document is a template. Sections marked with `COMPILE_FLAG_REPORT` markers 
 ## Flags (generated)
 
 <!-- BEGIN COMPILE_FLAG_REPORT:FLAGS -->
-Total flags: 87
+Total flags: 89
 
 ### Features (HAS_*)
 
@@ -105,6 +105,8 @@ Total flags: 87
 - **DISPLAY_INVERSION_ON** default: `(no default)` — Enable display inversion (panel-specific).
 - **DISPLAY_NEEDS_GAMMA_FIX** default: `(no default)` — Apply gamma correction fix for this panel variant.
 - **ESP_PANEL_SWAPBUF_PREFER_INTERNAL** default: `true` — Prefer internal RAM over PSRAM for ESP_Panel swap buffer allocation.
+- **HEALTH_HISTORY_SECONDS** default: `300UL` — Web portal health history window in seconds (client-side only).
+- **HEALTH_POLL_INTERVAL_MS** default: `5000UL` — samples to keep in its in-browser history buffers.
 - **HEARTBEAT_INTERVAL_MS** default: `60000UL` — Override per-board to speed up automated memory tests.
 - **LCD_QSPI_HOST** default: `(no default)` — QSPI host peripheral.
 - **LED_ACTIVE_HIGH** default: `true` — LED polarity: true if HIGH turns the LED on.
@@ -171,6 +173,7 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/board_config.h
   - src/app/config_manager.cpp
   - src/app/config_manager.h
+  - src/app/device_telemetry.cpp
   - src/app/display_drivers.cpp
   - src/app/display_manager.cpp
   - src/app/icon_store.cpp
@@ -219,6 +222,7 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/app.ino
   - src/app/board_config.h
   - src/app/config_manager.cpp
+  - src/app/device_telemetry.cpp
   - src/app/ha_discovery.cpp
   - src/app/ha_discovery.h
   - src/app/mqtt_manager.cpp
@@ -251,6 +255,10 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
 - **DISPLAY_ROTATION**
   - src/app/touch_manager.cpp
 - **ESP_PANEL_SWAPBUF_PREFER_INTERNAL**
+  - src/app/board_config.h
+- **HEALTH_HISTORY_SECONDS**
+  - src/app/board_config.h
+- **HEALTH_POLL_INTERVAL_MS**
   - src/app/board_config.h
 - **HEARTBEAT_INTERVAL_MS**
   - src/app/board_config.h

--- a/docs/web-portal.md
+++ b/docs/web-portal.md
@@ -408,10 +408,8 @@ Returns real-time device health statistics.
   "uptime_seconds": 3600,
   "reset_reason": "Power On",
   "cpu_usage": 15,
-  "cpu_usage_min": 8,
-  "cpu_usage_max": 32,
   "cpu_freq": 160,
-  "temperature": 42,
+  "cpu_temperature": 42,
   "heap_free": 250000,
   "heap_min": 240000,
   "heap_size": 327680,
@@ -426,8 +424,7 @@ Returns real-time device health statistics.
 ```
 
 **Notes:**
-- `cpu_usage_min`, `cpu_usage_max`: Minimum and maximum CPU usage over the last 60 seconds
-- `temperature`: `null` on chips without internal sensor (original ESP32)
+- `cpu_temperature`: `null` on chips without internal sensor (original ESP32)
 - `wifi_rssi`, `wifi_channel`, `ip_address`, `hostname`: `null` when not connected
 
 ### Configuration Management

--- a/src/app/api_core.cpp
+++ b/src/app/api_core.cpp
@@ -90,6 +90,10 @@ static void handleGetVersion(AsyncWebServerRequest* request) {
     doc["project_name"] = PROJECT_NAME;
     doc["project_display_name"] = PROJECT_DISPLAY_NAME;
 
+    // Web portal health widget configuration (client-side only).
+    doc["health_poll_interval_ms"] = HEALTH_POLL_INTERVAL_MS;
+    doc["health_history_seconds"] = HEALTH_HISTORY_SECONDS;
+
     // Build metadata for GitHub-based updates
 #ifdef BUILD_BOARD_NAME
     doc["board_name"] = BUILD_BOARD_NAME;

--- a/src/app/app.ino
+++ b/src/app/app.ino
@@ -152,6 +152,9 @@ void setup()
   // Start CPU monitoring background task
   device_telemetry_start_cpu_monitoring();
 
+  // Start /api/health window min/max sampler (captures short dips between polls)
+  device_telemetry_start_health_window_sampling();
+
   // Try to load saved configuration
   #if HAS_DISPLAY
   display_manager_set_splash_status("Reading config...");

--- a/src/app/board_config.h
+++ b/src/app/board_config.h
@@ -85,6 +85,18 @@
 #define HEARTBEAT_INTERVAL_MS 60000UL
 #endif
 
+// Web portal health polling cadence (client-side only).
+// Used by the portal to determine how often to poll /api/health and how many
+// samples to keep in its in-browser history buffers.
+#ifndef HEALTH_POLL_INTERVAL_MS
+#define HEALTH_POLL_INTERVAL_MS 5000UL
+#endif
+
+// Web portal health history window in seconds (client-side only).
+#ifndef HEALTH_HISTORY_SECONDS
+#define HEALTH_HISTORY_SECONDS 300UL
+#endif
+
 // When enabled, log memory snapshots from key runtime hotspots.
 // Originally added for HTTP handlers, but also used for other one-shot hotspot tags
 // (e.g. MQTT connect/discovery, macro apply, LVGL screen switch) so automated

--- a/src/app/device_telemetry.cpp
+++ b/src/app/device_telemetry.cpp
@@ -255,13 +255,7 @@ void device_telemetry_log_memory_snapshot(const char *tag) {
     // pf=psram_free pm=psram_min pl=psram_largest
     // frag=heap fragmentation percent (based on hl/hf)
 
-    unsigned frag_percent = 0;
-    if (heap_free > 0) {
-        float fragmentation = (1.0f - ((float)heap_largest / (float)heap_free)) * 100.0f;
-        if (fragmentation < 0) fragmentation = 0;
-        if (fragmentation > 100) fragmentation = 100;
-        frag_percent = (unsigned)fragmentation;
-    }
+    const unsigned frag_percent = (unsigned)compute_fragmentation_percent(heap_free, heap_largest);
 
     Logger.logMessagef(
         "Mem",

--- a/src/app/device_telemetry.h
+++ b/src/app/device_telemetry.h
@@ -33,9 +33,6 @@ void device_telemetry_fill_mqtt(JsonDocument &doc);
 // Thread-safe - reads cached value updated by background task.
 int device_telemetry_get_cpu_usage();
 
-// Get CPU usage min/max over the last 60 seconds.
-void device_telemetry_get_cpu_minmax(int* out_min, int* out_max);
-
 // Initialize CPU monitoring background task.
 // Must be called once during setup.
 void device_telemetry_start_cpu_monitoring();

--- a/src/app/device_telemetry.h
+++ b/src/app/device_telemetry.h
@@ -40,6 +40,11 @@ void device_telemetry_get_cpu_minmax(int* out_min, int* out_max);
 // Must be called once during setup.
 void device_telemetry_start_cpu_monitoring();
 
+// Start background sampling for /api/health window min/max metrics.
+// Tracks min/max between /api/health calls and resets when /api/health is served.
+// Safe to call multiple times.
+void device_telemetry_start_health_window_sampling();
+
 // Capture a point-in-time memory snapshot (heap/internal heap/PSRAM).
 DeviceMemorySnapshot device_telemetry_get_memory_snapshot();
 

--- a/src/app/display_manager.h
+++ b/src/app/display_manager.h
@@ -225,6 +225,17 @@ public:
 // Global instance (managed by app.ino)
 extern DisplayManager* displayManager;
 
+// Lightweight perf stats updated by the LVGL rendering task.
+// Safe to read from non-LVGL tasks (e.g., AsyncTCP /api/health handler).
+typedef struct DisplayPerfStats {
+    uint16_t fps;
+    uint32_t lv_timer_us;
+    uint32_t present_us;
+} DisplayPerfStats;
+
+// Returns true if stats are available (HAS_DISPLAY).
+bool display_manager_get_perf_stats(DisplayPerfStats* out);
+
 // C-style interface for app.ino
 void display_manager_init(DeviceConfig* config);
 void display_manager_show_splash();

--- a/src/app/fs_health.cpp
+++ b/src/app/fs_health.cpp
@@ -1,0 +1,48 @@
+#include "fs_health.h"
+
+#include <string.h>
+
+#if defined(ARDUINO_ARCH_ESP32)
+#include <esp_partition.h>
+#endif
+
+namespace {
+static bool g_inited = false;
+static FSHealthStats g_stats = {
+    .ffat_partition_present = false,
+    .ffat_mounted = false,
+    .ffat_used_bytes = 0,
+    .ffat_total_bytes = 0,
+};
+
+static void detect_partitions() {
+#if defined(ARDUINO_ARCH_ESP32)
+    const esp_partition_t* ffat_part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA,
+        ESP_PARTITION_SUBTYPE_DATA_FAT,
+        "ffat");
+    g_stats.ffat_partition_present = (ffat_part != nullptr);
+#else
+    g_stats.ffat_partition_present = false;
+#endif
+}
+} // namespace
+
+void fs_health_init() {
+    if (g_inited) return;
+    g_inited = true;
+    detect_partitions();
+}
+
+void fs_health_set_ffat_usage(uint32_t used_bytes, uint32_t total_bytes) {
+    // Treat this as a one-way latch: once mounted, keep reporting mounted.
+    g_stats.ffat_mounted = true;
+    g_stats.ffat_used_bytes = used_bytes;
+    g_stats.ffat_total_bytes = total_bytes;
+}
+
+void fs_health_get(FSHealthStats* out) {
+    if (!g_inited) fs_health_init();
+    if (!out) return;
+    memcpy(out, &g_stats, sizeof(g_stats));
+}

--- a/src/app/fs_health.h
+++ b/src/app/fs_health.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Cached, low-overhead filesystem health information.
+//
+// Design goals:
+// - /api/health must never mount/probe filesystems (avoid heap churn and latency)
+// - Filesystem availability/type is cached at boot (partition table)
+// - Usage numbers are only reported after some other subsystem has mounted the FS
+//   and provided totals via fs_health_set_ffat_usage().
+
+typedef struct FSHealthStats {
+    bool ffat_partition_present;
+    bool ffat_mounted;
+    uint32_t ffat_used_bytes;
+    uint32_t ffat_total_bytes;
+} FSHealthStats;
+
+void fs_health_init();
+
+// Called by subsystems that successfully mounted FFat.
+void fs_health_set_ffat_usage(uint32_t used_bytes, uint32_t total_bytes);
+
+// Returns cached stats (always succeeds after fs_health_init()).
+void fs_health_get(FSHealthStats* out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/app/ha_discovery.cpp
+++ b/src/app/ha_discovery.cpp
@@ -29,8 +29,6 @@ void ha_discovery_publish_health(MqttManager &mqtt) {
     publish_sensor_config(mqtt, "reset_reason", "Reset Reason", "{{ value_json.reset_reason }}", "", "", "", "diagnostic");
 
     publish_sensor_config(mqtt, "cpu_usage", "CPU Usage", "{{ value_json.cpu_usage }}", "%", "", "measurement", "diagnostic");
-    publish_sensor_config(mqtt, "cpu_usage_min", "CPU Usage Min", "{{ value_json.cpu_usage_min }}", "%", "", "measurement", "diagnostic");
-    publish_sensor_config(mqtt, "cpu_usage_max", "CPU Usage Max", "{{ value_json.cpu_usage_max }}", "%", "", "measurement", "diagnostic");
     publish_sensor_config(mqtt, "cpu_temperature", "Core Temp", "{{ value_json.cpu_temperature }}", "°C", "temperature", "measurement", "diagnostic");
 
     publish_sensor_config(mqtt, "heap_free", "Free Heap", "{{ value_json.heap_free }}", "B", "", "measurement", "diagnostic");

--- a/src/app/icon_store.cpp
+++ b/src/app/icon_store.cpp
@@ -6,6 +6,8 @@
 #include <FFat.h>
 #include <esp_partition.h>
 
+#include "fs_health.h"
+
 #include <string.h>
 
 namespace {
@@ -51,6 +53,11 @@ static bool ensure_ffat() {
     }
 
     ffat_ready = FFat.begin(false);
+    if (ffat_ready) {
+        // Report usage to the health module (best-effort). This is called only
+        // when some icon operation needed FFat, not from /api/health.
+        fs_health_set_ffat_usage((uint32_t)FFat.usedBytes(), (uint32_t)FFat.totalBytes());
+    }
     return ffat_ready;
 }
 

--- a/src/app/mqtt_manager.h
+++ b/src/app/mqtt_manager.h
@@ -28,6 +28,10 @@ public:
     bool publishEnabled() const;
     bool connected();
 
+    // Status / instrumentation (safe to read from other tasks)
+    unsigned long lastReconnectAttemptMs() const { return _last_reconnect_attempt_ms; }
+    unsigned long lastHealthPublishMs() const { return _last_health_publish_ms; }
+
     // Publish helpers
     bool publish(const char *topic, const char *payload, bool retained);
     bool publishJson(const char *topic, JsonDocument &doc, bool retained);
@@ -74,6 +78,9 @@ private:
     unsigned long _last_reconnect_attempt_ms = 0;
     unsigned long _last_health_publish_ms = 0;
 };
+
+// Global instance is defined in app.ino when HAS_MQTT is enabled.
+extern MqttManager mqtt_manager;
 
 #endif // HAS_MQTT
 

--- a/src/app/web/_footer.html
+++ b/src/app/web/_footer.html
@@ -67,10 +67,6 @@
                     <span class="health-value" id="health-cpu-full">--</span>
                 </div>
                 <div class="health-stat">
-                    <span class="health-label">CPU Min/Max (60s)</span>
-                    <span class="health-value" id="health-cpu-minmax">--</span>
-                </div>
-                <div class="health-stat">
                     <span class="health-label">Core Temp</span>
                     <span class="health-value" id="health-temp">--</span>
                 </div>

--- a/src/app/web/_footer.html
+++ b/src/app/web/_footer.html
@@ -19,6 +19,39 @@
                 <button type="button" id="health-close" class="health-close-btn">✕</button>
             </div>
             <div class="health-stats">
+                <!-- Sparklines (client-side history only) -->
+                <div class="health-sparkline" id="health-sparkline-cpu-wrap">
+                    <div class="health-sparkline-row">
+                        <span class="health-label">CPU Usage</span>
+                        <span class="health-value" id="health-sparkline-cpu-value">--</span>
+                    </div>
+                    <canvas id="health-sparkline-cpu" width="260" height="44"></canvas>
+                </div>
+
+                <div class="health-sparkline" id="health-sparkline-heap-wrap">
+                    <div class="health-sparkline-row">
+                        <span class="health-label">Internal Free Heap</span>
+                        <span class="health-value" id="health-sparkline-heap-value">--</span>
+                    </div>
+                    <canvas id="health-sparkline-heap" width="260" height="44"></canvas>
+                </div>
+
+                <div class="health-sparkline" id="health-sparkline-psram-wrap" style="display:none;">
+                    <div class="health-sparkline-row">
+                        <span class="health-label">PSRAM Free</span>
+                        <span class="health-value" id="health-sparkline-psram-value">--</span>
+                    </div>
+                    <canvas id="health-sparkline-psram" width="260" height="44"></canvas>
+                </div>
+
+                <div class="health-sparkline" id="health-sparkline-rssi-wrap">
+                    <div class="health-sparkline-row">
+                        <span class="health-label">WiFi RSSI</span>
+                        <span class="health-value" id="health-sparkline-rssi-value">--</span>
+                    </div>
+                    <canvas id="health-sparkline-rssi" width="260" height="44"></canvas>
+                </div>
+
                 <!-- System -->
                 <div class="health-stat">
                     <span class="health-label">Uptime</span>
@@ -51,13 +84,47 @@
                     <span class="health-value" id="health-heap-min">--</span>
                 </div>
                 <div class="health-stat">
-                    <span class="health-label">Heap Fragmentation</span>
+                    <span class="health-label">Internal Heap Fragmentation</span>
                     <span class="health-value" id="health-heap-frag">--</span>
+                </div>
+                <div class="health-stat">
+                    <span class="health-label">Internal Min Free Heap</span>
+                    <span class="health-value" id="health-internal-min">--</span>
+                </div>
+                <div class="health-stat">
+                    <span class="health-label">Internal Largest Block</span>
+                    <span class="health-value" id="health-internal-largest">--</span>
+                </div>
+                <div class="health-stat" id="health-psram-min-wrap" style="display:none;">
+                    <span class="health-label">PSRAM Min Free Heap</span>
+                    <span class="health-value" id="health-psram-min">--</span>
+                </div>
+                <div class="health-stat" id="health-psram-frag-wrap" style="display:none;">
+                    <span class="health-label">PSRAM Fragmentation</span>
+                    <span class="health-value" id="health-psram-frag">--</span>
                 </div>
                 <!-- Storage -->
                 <div class="health-stat">
                     <span class="health-label">Flash Usage</span>
                     <span class="health-value" id="health-flash">--</span>
+                </div>
+                <div class="health-stat">
+                    <span class="health-label">FS</span>
+                    <span class="health-value" id="health-fs">--</span>
+                </div>
+                <!-- Display -->
+                <div class="health-stat">
+                    <span class="health-label">Rendered FPS</span>
+                    <span class="health-value" id="health-display-fps">--</span>
+                </div>
+                <div class="health-stat">
+                    <span class="health-label">LVGL Handler / Present</span>
+                    <span class="health-value" id="health-display-times">--</span>
+                </div>
+                <!-- MQTT -->
+                <div class="health-stat">
+                    <span class="health-label">MQTT</span>
+                    <span class="health-value" id="health-mqtt">--</span>
                 </div>
                 <!-- Network -->
                 <div class="health-stat">

--- a/src/app/web/_footer.html
+++ b/src/app/web/_footer.html
@@ -109,7 +109,7 @@
                     <span class="health-value" id="health-flash">--</span>
                 </div>
                 <div class="health-stat">
-                    <span class="health-label">FS</span>
+                    <span class="health-label">File System</span>
                     <span class="health-value" id="health-fs">--</span>
                 </div>
                 <!-- Display -->

--- a/src/app/web/portal.css
+++ b/src/app/web/portal.css
@@ -1189,6 +1189,46 @@ body.portal-overlay-open {
     width: 100%;
     height: 44px;
     display: block;
+    cursor: crosshair;
+}
+
+.health-sparkline-tooltip {
+    position: fixed;
+    z-index: 2500;
+    pointer-events: none;
+    background: rgba(17, 24, 39, 0.92);
+    color: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 10px;
+    padding: 10px 12px;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+    font-size: 12px;
+    line-height: 1.25;
+    max-width: 320px;
+    backdrop-filter: blur(8px);
+}
+
+.health-sparkline-tooltip-title {
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.health-sparkline-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    opacity: 0.85;
+    margin-bottom: 6px;
+}
+
+.health-sparkline-tooltip-value {
+    font-weight: 800;
+    font-size: 13px;
+}
+
+.health-sparkline-tooltip-sub {
+    margin-top: 4px;
+    opacity: 0.85;
 }
 
 .health-stat {

--- a/src/app/web/portal.css
+++ b/src/app/web/portal.css
@@ -1122,6 +1122,8 @@ body.portal-overlay-open {
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
     min-width: 280px;
     border: 2px solid #d0e7ff;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
 }
 
 .health-header {
@@ -1166,6 +1168,27 @@ body.portal-overlay-open {
     display: flex;
     flex-direction: column;
     gap: 4px;
+}
+
+.health-sparkline {
+    background: rgba(255, 255, 255, 0.75);
+    border: 1px solid #d0e7ff;
+    border-radius: 12px;
+    padding: 10px;
+    margin-bottom: 6px;
+}
+
+.health-sparkline-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 6px;
+}
+
+.health-sparkline canvas {
+    width: 100%;
+    height: 44px;
+    display: block;
 }
 
 .health-stat {

--- a/src/app/web/portal.js
+++ b/src/app/web/portal.js
@@ -3971,11 +3971,6 @@ async function updateHealth() {
         
         // CPU
         document.getElementById('health-cpu-full').textContent = (cpuUsage !== null) ? `${cpuUsage}%` : '—';
-        if (cpuUsage !== null && typeof health.cpu_usage_min === 'number' && typeof health.cpu_usage_max === 'number') {
-            document.getElementById('health-cpu-minmax').textContent = `${health.cpu_usage_min}% / ${health.cpu_usage_max}%`;
-        } else {
-            document.getElementById('health-cpu-minmax').textContent = '—';
-        }
         document.getElementById('health-temp').textContent = health.cpu_temperature !== null ? 
             `${health.cpu_temperature}°C` : 'N/A';
 

--- a/src/version.h
+++ b/src/version.h
@@ -5,8 +5,8 @@
 
 // Firmware version information
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 4
-#define VERSION_PATCH 3
+#define VERSION_MINOR 5
+#define VERSION_PATCH 0
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
This PR improves runtime observability via the web portal “health overlay” and `/api/health`, while staying focused on internal-RAM safety and template/backport friendliness. It also bumps the firmware version to **v1.5.0** and updates the changelog.

## Goals / Constraints (from artifacts/20260114_health_ui_requirements.md)
- Keep internal RAM pressure stable: avoid new heap churn/fragmentation and expensive per-request work on the AsyncTCP task.
- Keep the solution template/backport-friendly: boards without PSRAM must degrade gracefully.
- Keep it KISS & DRY: centralize telemetry building and keep UI resilient to missing fields.
- Keep history client-side only: sparklines are driven by browser history buffers, not firmware time series.

## User-facing behavior
### Health overlay + sparklines
- Header health bubble stays **CPU-only**; click/tap opens the overlay.
- Overlay is vertically scrollable.
- Portal continuously polls `/api/health` (even when overlay is closed) to build **client-side** history.
- Sparklines tracked:
  - CPU usage
  - Internal heap free (with shaded min/max band)
  - PSRAM free (with shaded band; only shown if PSRAM exists)
  - WiFi RSSI

### Hover/touch inspection
- Hover/touch snaps to the nearest sample index; draws a small dot at the hovered point.
- Tooltip shows time-of-day + age (e.g. `12:03:20` / `15s ago`).
- For heap/PSRAM it also shows window min/max and Δ (max-min).
- Tooltip also shows sparkline min/max (computed client-side; for heap/PSRAM includes both line + band arrays).

## Firmware / API behavior
### `/api/health` robustness
- CPU usage is computed by a low-priority background task (~1 Hz).
- If FreeRTOS runtime stats are unavailable, or task sampling would be truncated, CPU usage is treated as **unknown**:
  - `/api/health` returns `cpu_usage: null`
  - UI displays `—` and does not record a bogus 0% sample

### Windowed min/max sampling (between polls)
- Adds a low-overhead 200ms FreeRTOS software timer sampler to capture short-lived dips/spikes between `/api/health` polls.
- Window reset semantics: after each `/api/health` response, the window is reset and immediately seeded with the current values.

### Filesystem
- `/api/health` reports only **cached** FS stats (no mount/probe work inside the handler).
- Overlay label is **File System**.

### MQTT
- Adds health fields (no secrets): supported/configured/connected/publish enabled/last publish age.

### Display
- Adds display performance metrics when `HAS_DISPLAY` is enabled (FPS + timings).

## Breaking / notable changes
- Removes CPU usage min/max fields everywhere (API/UI/MQTT/Home Assistant discovery).
  - If you previously had HA entities from the old discovery payload, they may need manual cleanup (clearing retained discovery topics / deleting stale entities).

## Docs
- Updates API docs example payload in docs/web-portal.md.
- Regenerates docs/compile-time-flags.md via tools/compile_flags_report.py.
- Full design/requirements reference: artifacts/20260114_health_ui_requirements.md.

## Testing
- `./build.sh jc3636w518`
